### PR TITLE
Fix: EVL detachment near DEB (closes #28)

### DIFF
--- a/app/simulation/agents.py
+++ b/app/simulation/agents.py
@@ -163,10 +163,17 @@ class AgentsSystem:
             return
 
         # Step 1: Update each cell (with optional stiffness gradient for durotaxis)
+        # Cells near the DEB boundary detach from EVL mechanotaxis to allow
+        # horizontal spreading and cluster formation (issue #28).
         for cell in self.cells:
             if cell.active:
-                gradient = env.get_stiffness_gradient(cell.position) if hasattr(env, 'get_stiffness_gradient') else None
-                cell.simulation_step(mechanotaxis_gradient=gradient)
+                near_deb = env.deb_enabled and (cell.position[1] > env.deb_position - 3 * cell.base_radius)
+                if not near_deb:
+                    gradient = env.get_stiffness_gradient(cell.position) if hasattr(env, 'get_stiffness_gradient') else None
+                    cell.simulation_step(mechanotaxis_gradient=gradient)
+                else:
+                    # Near DEB: cell is free from EVL, only stochastic motion
+                    cell.simulation_step(mechanotaxis_gradient=None)
 
         # Step 2: Resolve collisions (two-pass)
         self._resolve_collisions()
@@ -273,8 +280,9 @@ class AgentsSystem:
             cell.position[0] = np.clip(cell.position[0], r, env.width - r)
             cell.position[1] = np.clip(cell.position[1], r, env.height - r)
 
-            # EVL boundary (upper)
-            if env.evl_enabled and cell.position[1] < env.evl_position:
+            # EVL boundary (upper) — only for cells NOT near DEB (issue #28)
+            near_deb = env.deb_enabled and (cell.position[1] > env.deb_position - 3 * r)
+            if env.evl_enabled and cell.position[1] < env.evl_position and not near_deb:
                 cell.position[1] = env.evl_position + r
 
             # DEB boundary (lower)


### PR DESCRIPTION
## Summary
- Cells now detach from EVL when within 3*radius of DEB boundary
- Prevents single-line squeezing, allows cluster structures to form
- Closes #28

## Test plan
- [ ] `python tests/test_agents.py && python tests/test_simulation.py`

@codex The EVL-DEB boundary interaction now has a proximity switch. Can you think of a smoother transition function than a hard cutoff at 3R? Maybe a sigmoid? What would the biological justification be? 🧬

_@codex La interacción EVL-DEB ahora tiene un switch de proximidad. ¿Se te ocurre una función de transición más suave que un corte duro a 3R? ¿Quizás una sigmoide?_ 🇪🇸

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

**NOTE to @codex: This is a CODE REVIEW only. Do NOT ask for an environment. Just read the diff and comment on the physics.**