### PR TITLE
Docs: Document cPanel/Passenger deployment path

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,23 @@ SCIAN_LEO_CPM/
 ├── build.spec                     # PyInstaller spec file
 ├── Build_PyInstaller.ps1          # PowerShell build script
 ├── run_app.py                     # Uvicorn launcher with auto-browser
+├── passenger_wsgi.py              # cPanel/Passenger ASGI entry point
 ├── requirements.txt               # Python dependencies
 └── README.md                      # This file
 ```
+
+---
+
+## Deployment
+
+| Target | Entry point | Notes |
+|--------|-------------|-------|
+| Local dev | `python -m uvicorn app.main:app --reload --port 8001` | Auto-reload on file change |
+| Production (single worker) | `uvicorn app.main:app --host 0.0.0.0 --port 8001 --workers 1` | State is in-process — single worker only |
+| cPanel shared hosting | `passenger_wsgi.py` with `application` symbol | WebSocket requires `Upgrade`/`Connection` headers forwarded |
+| Docker | See Dockerfile snippet in [docs/architecture.md](docs/architecture.md) | Provided as a template, not included in repo |
+
+See [Deployment Options](docs/architecture.md#deployment-options) in the architecture doc for details.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,6 +224,30 @@ COPY . .
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]
 ```
 
+### cPanel / Passenger (shared hosting)
+
+The repository includes a `passenger_wsgi.py` entry point that exposes the FastAPI ASGI application under the name `application`, which is the symbol Passenger looks up by default:
+
+```python
+# passenger_wsgi.py
+import sys, os
+sys.path.insert(0, os.path.dirname(__file__))
+from app.main import app as application
+```
+
+To deploy under cPanel with Passenger:
+
+1. Create a Python application in cPanel pointing at the repository root.
+2. Set the application startup file to `passenger_wsgi.py` and the application entry point to `application`.
+3. In the application's virtual environment, run `pip install -r requirements.txt`.
+4. Restart the Python application from cPanel.
+
+Notes specific to Passenger:
+
+- Passenger spawns a fresh worker per request pool. Because the simulation state lives in a process-local Python object, long-running WebSocket sessions require a single persistent worker. If cPanel is configured with multiple workers, only one of them will see a given simulation state.
+- The `/ws/simulation` endpoint needs WebSocket support at the reverse proxy layer (LiteSpeed handles this transparently; Apache with mod_passenger needs the `Upgrade`/`Connection` headers forwarded).
+- If the hosting provider restricts outbound ports or WebSocket upgrades, the application gracefully degrades to REST `step` mode, which uses plain HTTP POST requests.
+
 ---
 
 ## Performance Considerations


### PR DESCRIPTION
Closes #41

## Summary

- Adds a dedicated "cPanel / Passenger" subsection to `docs/architecture.md` with setup steps, worker caveats, and WebSocket notes.
- Adds a Deployment table to `README.md` mapping every supported target (local dev, production, cPanel, Docker) to its entry point.
- Lists `passenger_wsgi.py` in the README project structure tree so deployers find it without digging through the repo root.

## Rationale

Commit 5a808c2 added the Passenger entry point with no accompanying documentation. This PR closes that gap so that a new operator can deploy on cPanel without reverse-engineering the intent of `passenger_wsgi.py`.

## Test Plan

- [x] `docs/architecture.md` renders correctly on GitHub (headings, code block, bullet list).
- [x] `README.md` table renders correctly and all internal links resolve (`docs/architecture.md#deployment-options`).
- [x] No code changes; test suite unaffected.