### PR TITLE
Feat: Add /api/health endpoint and Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# Keep the image slim: exclude dev/test assets, VCS metadata, and large
+# legacy artifacts that are not needed at runtime.
+
+# VCS and CI
+.git
+.github
+.gitignore
+.gitattributes
+
+# Python virtual envs and caches
+.venv
+venv
+env
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.coverage
+htmlcov
+
+# Editor / OS cruft
+.vscode
+.idea
+.claude
+*.swp
+.DS_Store
+Thumbs.db
+
+# Test, notebook, and build artifacts
+tests
+notebooks
+build
+dist
+*.egg-info
+
+# Documentation (not needed at runtime)
+docs
+README.md
+LICENSE
+
+# Legacy C++/CLI codebase (pre-2024) -- not used by the ASGI app
+legacy
+
+# PyInstaller spec/helpers
+build.spec
+Build_PyInstaller.ps1
+
+# Container infra (avoid recursive copy)
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# SCIAN_LEO_CPM - Cellular Potts Model simulator
+#
+# Multi-stage-free slim image: Python 3.12 + uvicorn serving FastAPI on :8001.
+# The image embeds only the runtime surface (app/, requirements.txt); legacy/,
+# tests/, notebooks/, and docs/ are excluded via .dockerignore.
+#
+# Build:
+#   docker build -t scian-leo-cpm:latest .
+# Run:
+#   docker run --rm -p 8001:8001 scian-leo-cpm:latest
+# Then open http://localhost:8001 in a browser.
+#
+# Health check:
+#   curl -f http://localhost:8001/api/health
+
+FROM python:3.12-slim
+
+# Avoid interactive prompts, keep image small, disable pip cache.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Install dependencies first so this layer is cached when source code changes.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application source. .dockerignore prunes legacy/, tests/, notebooks/.
+COPY app ./app
+COPY run_app.py ./
+
+EXPOSE 8001
+
+# Container-level health probe hits the /api/health route added in PR #43/#44.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request,sys; \
+sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8001/api/health', timeout=3).status == 200 else 1)"
+
+# Single worker because simulation_state is an in-process singleton.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001", "--workers", "1"]

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The **sin** function creates a restoring torque: filopodia aligned with the stif
 
 | Metric | Status |
 |--------|--------|
-| Tests | 19 passing |
+| Tests | 30 passing |
 | Cell behaviors | 5 (filopodia, adhesion, CIL, durotaxis, Hertwig division) |
 | Collision algorithm | Two-pass O(n²), <1ms for 24 cells |
 | Vectorization | NumPy broadcasting for adhesion, contour generation |
@@ -166,6 +166,7 @@ SCIAN_LEO_CPM/
 │   │   └── math_utils.py          # Vector math, angle normalization helpers
 │   ├── api/
 │   │   ├── __init__.py
+│   │   ├── health.py              # /api/health liveness probe
 │   │   └── websocket.py           # WebSocket endpoint and docs
 │   └── static/                    # Browser frontend
 │       ├── index.html             # Single-page application
@@ -204,6 +205,8 @@ SCIAN_LEO_CPM/
 ├── Build_PyInstaller.ps1          # PowerShell build script
 ├── run_app.py                     # Uvicorn launcher with auto-browser
 ├── passenger_wsgi.py              # cPanel/Passenger ASGI entry point
+├── Dockerfile                     # Python 3.12-slim image, serves :8001 with HEALTHCHECK
+├── .dockerignore                  # Prunes legacy/, tests/, notebooks/, .venv/
 ├── requirements.txt               # Python dependencies
 └── README.md                      # This file
 ```
@@ -217,7 +220,7 @@ SCIAN_LEO_CPM/
 | Local dev | `python -m uvicorn app.main:app --reload --port 8001` | Auto-reload on file change |
 | Production (single worker) | `uvicorn app.main:app --host 0.0.0.0 --port 8001 --workers 1` | State is in-process — single worker only |
 | cPanel shared hosting | `passenger_wsgi.py` with `application` symbol | WebSocket requires `Upgrade`/`Connection` headers forwarded |
-| Docker | See Dockerfile snippet in [docs/architecture.md](docs/architecture.md) | Provided as a template, not included in repo |
+| Docker | `docker build -t scian-leo-cpm .` then `docker run --rm -p 8001:8001 scian-leo-cpm` | Uses `Dockerfile` + `.dockerignore` at repo root; `HEALTHCHECK` probes `/api/health` |
 
 See [Deployment Options](docs/architecture.md#deployment-options) in the architecture doc for details.
 
@@ -235,6 +238,7 @@ The server automatically generates interactive API documentation:
 | Method | Endpoint                   | Description                          |
 |--------|----------------------------|--------------------------------------|
 | GET    | `/`                        | Serve the web application            |
+| GET    | `/api/health`              | Liveness probe — `{status, version, sim_initialized}` for load balancers / Docker |
 | POST   | `/api/simulation/init`     | Initialize simulation with config    |
 | POST   | `/api/simulation/start`    | Start continuous simulation          |
 | POST   | `/api/simulation/stop`     | Pause simulation                     |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,3 +4,5 @@ SCIAN_LEO_CPM - Cellular Potts Model Web Application.
 A FastAPI-based interactive simulator for the Cellular Potts Model applied
 to zebrafish embryonic cell migration (DFC/EVL/DEB dynamics).
 """
+
+__version__ = "2.0.0"

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -1,0 +1,37 @@
+"""
+System health endpoints for liveness and deployment probes.
+
+Provides a cheap GET /api/health suitable for cPanel, Docker, and reverse-
+proxy health checks. Does not touch the simulation lock nor advance state,
+so it is safe to hit at high frequency.
+"""
+
+from fastapi import APIRouter
+
+from .. import __version__
+
+router = APIRouter(tags=["System"])
+
+
+@router.get("/api/health")
+async def health() -> dict:
+    """Liveness probe for load balancers and orchestrators.
+
+    Returns a small JSON payload indicating that the ASGI process is
+    responsive and whether a simulation has been initialized. Never
+    modifies simulation state.
+
+    Returns:
+        Dictionary with keys:
+            status: always ``"ok"`` when the handler executes.
+            version: application version from ``app.__version__``.
+            sim_initialized: ``True`` if ``/api/simulation/init`` has run.
+    """
+    # Import lazily to avoid circular import with app.main at startup
+    from ..main import simulation_state
+
+    return {
+        "status": "ok",
+        "version": __version__,
+        "sim_initialized": simulation_state.get("agents") is not None,
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -26,14 +26,19 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from typing import Optional
 
+from . import __version__
+from .api.health import router as health_router
 from .simulation.agents import AgentsSystem
 from .simulation.environment import EnvironmentSystem
 
 app = FastAPI(
     title="SCIAN LEO CPM",
     description="Cellular Potts Model simulator for zebrafish embryonic development",
-    version="2.0.0",
+    version=__version__,
 )
+
+# System-level routes (health checks). Tagged "System" in Swagger.
+app.include_router(health_router)
 
 # Serve static files
 static_dir = Path(__file__).parent / "static"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,18 +211,24 @@ uvicorn app.main:app --host 0.0.0.0 --port 8001 --workers 1
 
 Because the simulation state is stored in a global Python dictionary, multi-worker deployment is not supported. Each worker would have its own independent simulation state, leading to inconsistent behavior. For production use, run a single worker behind a reverse proxy (e.g., Nginx) if TLS or load balancing is needed.
 
-### Docker (optional)
+### Docker
 
-A Dockerfile is not included but would be straightforward:
+The repository ships a production-ready `Dockerfile` and `.dockerignore` at the
+root. The image is based on `python:3.12-slim`, installs `requirements.txt`,
+copies only the runtime surface (`app/`, `run_app.py`), exposes port 8001, and
+declares a `HEALTHCHECK` that hits `/api/health`.
 
-```dockerfile
-FROM python:3.12-slim
-WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]
+```bash
+docker build -t scian-leo-cpm:latest .
+docker run --rm -p 8001:8001 scian-leo-cpm:latest
+# Then open http://localhost:8001
 ```
+
+The `.dockerignore` excludes `legacy/`, `tests/`, `notebooks/`, `docs/`,
+`.venv/`, `.git/`, and editor caches so the image stays small. Because
+`simulation_state` is an in-process singleton, the `CMD` runs `uvicorn`
+with `--workers 1`; scale horizontally by running multiple containers
+behind a reverse proxy only if each container is assigned its own session.
 
 ### cPanel / Passenger (shared hosting)
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,64 @@
+"""Unit tests for the /api/health endpoint.
+
+The health route must be cheap, safe to hit at any frequency (it is used
+by cPanel, Docker, and reverse-proxy probes), and must never touch the
+simulation lock. The tests also verify the ``sim_initialized`` flag
+flips correctly after ``/api/simulation/init``.
+"""
+
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app import __version__
+from app.main import app, simulation_state
+
+
+def _reset_simulation_state() -> None:
+    """Tests run against the global ``simulation_state``; reset between cases."""
+    simulation_state["env"] = None
+    simulation_state["agents"] = None
+    simulation_state["running"] = False
+
+
+def test_health_ok_before_init():
+    """Health endpoint returns 200 and sim_initialized=False on a fresh process."""
+    _reset_simulation_state()
+    client = TestClient(app)
+
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["version"] == __version__
+    assert payload["sim_initialized"] is False
+    print("PASS: test_health_ok_before_init")
+
+
+def test_health_sim_initialized_flag_flips():
+    """After /api/simulation/init, health reports sim_initialized=True."""
+    _reset_simulation_state()
+    client = TestClient(app)
+
+    # Initialize with a tiny simulation to keep the test fast.
+    init_payload = {"num_cells": 3, "cell_radius": 8.0}
+    init_resp = client.post("/api/simulation/init", json=init_payload)
+    assert init_resp.status_code == 200
+
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["sim_initialized"] is True
+    print("PASS: test_health_sim_initialized_flag_flips")
+
+
+if __name__ == "__main__":
+    test_health_ok_before_init()
+    test_health_sim_initialized_flag_flips()
+    print("\nAll health tests passed!")


### PR DESCRIPTION
## Summary

- Adds `GET /api/health` returning `{status, version, sim_initialized}` under a Swagger **System** tag; never touches the simulation lock so it is safe to probe at any frequency.
- Promotes the previously docs-only Docker snippet to a real `Dockerfile` + `.dockerignore` at repo root; container declares a `HEALTHCHECK` that hits `/api/health`.
- Centralizes `__version__` in `app/__init__.py` (was a hardcoded string in `main.py`), and the FastAPI app now reads its version from there.

## Changes

- `app/__init__.py`: exposes `__version__ = "2.0.0"`.
- `app/api/health.py`: new `APIRouter` tagged `System` with the `GET /api/health` route (lazy-imports `simulation_state` to avoid circular import).
- `app/main.py`: registers `health_router`, reads `version` from `__version__`.
- `tests/test_health.py`: 2 tests (fresh-process -> `sim_initialized=False`; after `POST /api/simulation/init` -> `True`). All 30 tests pass.
- `Dockerfile`: Python 3.12-slim, single-worker uvicorn on :8001, container HEALTHCHECK.
- `.dockerignore`: excludes `legacy/`, `tests/`, `notebooks/`, `docs/`, `.venv/`, `.git/`, editor caches.
- `README.md`: new row in REST endpoints table, rewritten Docker row in Deployment table, project-structure tree updated, tests count corrected (19 -> 30).
- `docs/architecture.md`: replaces the 'Docker (optional) - not included' note with docs for the real `Dockerfile`.

Closes #43
Closes #44

## Verification

- `pytest tests/ -q` -> 30 passed (2 new + 28 existing).
- Manual smoke test: `TestClient` hits `/api/health` -> 200 `{status: 'ok', version: '2.0.0', sim_initialized: false}`; `/openapi.json` shows `System` tag.
- `docker build` was not executed because Docker Desktop daemon was not running on this machine; Dockerfile follows the exact pattern already documented in `docs/architecture.md` (python:3.12-slim + pip install + uvicorn) and adds only a HEALTHCHECK + EXPOSE + explicit `--workers 1`.

## Test plan

- [x] All existing tests still pass
- [x] New health endpoint unit tests pass
- [x] `/api/health` returns expected payload before init
- [x] `sim_initialized` flips to true after `/api/simulation/init`
- [x] OpenAPI schema shows the `System` tag for `/api/health`
- [ ] Container build on a host with a running Docker daemon (deferred; Dockerfile syntax is a direct promotion of the already-documented snippet)